### PR TITLE
Remove extra `font-family:` for `h1`

### DIFF
--- a/content.css
+++ b/content.css
@@ -16,7 +16,7 @@ p {
 }
 
 h1 {
-    font-family: font-family: 'Open Sans', sans-serif;
+    font-family: 'Open Sans', sans-serif;
     font-weight: bold;
     text-transform: uppercase;
     color: #0F1F6B;


### PR DESCRIPTION
This should fix the font for the heading; presumably the double `font-family:` wasn't intentional

Before:

![image](https://user-images.githubusercontent.com/22133785/127757119-08ce513d-48ac-44d7-9cb0-868eeb7b2e6a.png)

After:

![image](https://user-images.githubusercontent.com/22133785/127757120-51866d47-d088-4684-975c-0358ab7dead8.png)

Have a nice day! :D